### PR TITLE
Support of Refresh Tokens for Google, MicrosoftAccount and AAD server flow authentication

### DIFF
--- a/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/MobileServiceClient.java
+++ b/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/MobileServiceClient.java
@@ -314,6 +314,22 @@ public class MobileServiceClient {
     }
 
     /**
+     * Refreshes access token with the identity provider for the logged in user.
+     * @return Refreshed Mobile Service user
+     */
+    public ListenableFuture<MobileServiceUser> refreshUser() {
+        return mLoginManager.refreshUser();
+    }
+
+    /**
+     * Refreshes access token with the identity provider for the logged in user.
+     * @param callback The callback to invoke when the authentication process finishes
+     */
+    public void refreshUser(final UserAuthenticationCallback callback) {
+        mLoginManager.refreshUser(callback);
+    }
+
+    /**
      * Invokes an interactive authentication process using the specified
      * Authentication Provider
      *


### PR DESCRIPTION
Azure App Service's Authentication / Authorization feature has made enabling app authentication extremely simple, whether you are working with client flow or server flow. Still, if you've worked with token-based authentication in the past, token expiry and refresh can be a hassle. To simplify this token refresh experience, we are adding Auth 2.0’s Refresh Token into Android client SDK. Instead of adding your own refresh logic for authentication.