### PR TITLE
Fixes #126 by checking JsonArray elements before casting to JsonObjects

### DIFF
--- a/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/query/QueryOperations.java
+++ b/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/query/QueryOperations.java
@@ -1121,7 +1121,7 @@ public class QueryOperations {
      * @param leftQuery  The destination query to be modified.
      * @param rightQuery The source query to be joined with the destination query.
      */
-    static void join(Query leftQuery, Query rightQuery) {
+    public static void join(Query leftQuery, Query rightQuery) {
         if (leftQuery == null) {
             throw new IllegalArgumentException("Left Mobile Service query cannot be null.");
         }

--- a/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/serialization/JsonEntityParser.java
+++ b/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/serialization/JsonEntityParser.java
@@ -52,7 +52,7 @@ public class JsonEntityParser {
             JsonArray elements = results.getAsJsonArray();
 
             for (JsonElement element : elements) {
-                if (results.isJsonObject()) {
+                if (element.isJsonObject()) {
                     changeIdPropertyName(element.getAsJsonObject(), idPropertyName);
                 }
                 E typedElement = gson.fromJson(element, clazz);

--- a/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/serialization/JsonEntityParser.java
+++ b/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/table/serialization/JsonEntityParser.java
@@ -52,7 +52,9 @@ public class JsonEntityParser {
             JsonArray elements = results.getAsJsonArray();
 
             for (JsonElement element : elements) {
-                changeIdPropertyName(element.getAsJsonObject(), idPropertyName);
+                if (results.isJsonObject()) {
+                    changeIdPropertyName(element.getAsJsonObject(), idPropertyName);
+                }
                 E typedElement = gson.fromJson(element, clazz);
                 result.add(typedElement);
             }


### PR DESCRIPTION
Fixes #126 by checking JsonArray elements before casting to JsonObjects
Does not address any other parsing exceptions that could cause a similar problem.