### PR TITLE
Slight modernizations to allow for working CI builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To get the source code of our SDKs and samples via **git** just type:
 ## Android SDK
 Microsoft Azure Mobile Services can be used with an Android-based device using our Android SDK. You can get the Android SDK in one of the following two ways or you can download the source code using the instructions above.
 
-1. For an Android studio project, add the line `compile 'com.microsoft.azure:azure-mobile-android:3.4.0@aar'` to the app’s Gradle.build file with your desired SDK version plugged in (you can find the latest versions [here](https://go.microsoft.com/fwLink/?LinkID=525472&clcid=0x409)):
+1. For an Android studio project, add the line `compile 'com.microsoft.azure:azure-mobile-android:3.5.0@aar'` to the app’s Gradle.build file with your desired SDK version plugged in (you can find the latest versions [here](https://go.microsoft.com/fwLink/?LinkID=525472&clcid=0x409)):
 2. Eclipse users can [download the Android SDK](http://go.microsoft.com/fwlink/?LinkID=717033&clcid=0x409) directly or can download the source code using the instructions above.
 
 ### Prerequisites

--- a/sdk/android-libraries.gradle
+++ b/sdk/android-libraries.gradle
@@ -2,11 +2,10 @@ apply plugin: 'maven'
 
 def myProject = project
 
+def isCI = project.hasProperty('isCI') ? Boolean.valueOf(isCI) : false
+
 def BINTRAY_USERNAME = "$System.env.BINTRAY_USERNAME"
 def BINTRAY_APIKEY = "$System.env.BINTRAY_APIKEY"
-
-def isCI = project.hasProperty('isCI') ? Boolean.valueOf(isCI) : false
-def repoUrl = isCI ? "file://" + "$System.env.BUILD_ARTIFACTSTAGINGDIRECTORY" : 'https://api.bintray.com/maven/microsoftazuremobile/SDK/Mobile-Apps-Android'
 
 // step 2
 uploadArchives {
@@ -15,7 +14,7 @@ uploadArchives {
         pom.artifactId = PUBLISH_ARTIFACT_ID
         pom.version = myProject.version
         repository (
-            url: repoUrl
+            url: isCI ? "file://" + "$System.env.BUILD_ARTIFACTSTAGINGDIRECTORY" : REPO_URL
         ) {
             authentication(
                 userName: BINTRAY_USERNAME,

--- a/sdk/android-libraries.gradle
+++ b/sdk/android-libraries.gradle
@@ -2,6 +2,12 @@ apply plugin: 'maven'
 
 def myProject = project
 
+def BINTRAY_USERNAME = "$System.env.BINTRAY_USERNAME"
+def BINTRAY_APIKEY = "$System.env.BINTRAY_APIKEY"
+
+def isCI = project.hasProperty('isCI') ? Boolean.valueOf(isCI) : false
+def repoUrl = isCI ? "file://" + "$System.env.BUILD_ARTIFACTSTAGINGDIRECTORY" : 'https://api.bintray.com/maven/microsoftazuremobile/SDK/Mobile-Apps-Android'
+
 // step 2
 uploadArchives {
     repositories.mavenDeployer {
@@ -9,29 +15,32 @@ uploadArchives {
         pom.artifactId = PUBLISH_ARTIFACT_ID
         pom.version = myProject.version
         repository (
-                url: 'https://api.bintray.com/maven/microsoftazuremobile/SDK/Mobile-Apps-Android'
+            url: repoUrl
         ) {
             authentication(
-                    userName: 'bintray username',
-                    password: 'bintray api key'
+                userName: BINTRAY_USERNAME,
+                password: BINTRAY_APIKEY
             )
         }
     }
 }
 
-task clearJar(type: Delete) {
-    delete 'build/release/' + PUBLISH_ARTIFACT_ID + '-' + myProject.version + '.jar'
+
+task clearAar(type: Delete) {
+    delete 'build/release/' + PUBLISH_ARTIFACT_ID + '-' + myProject.version + '.aar'
 }
 
 // step 1
-task makeJar(type: Copy) {
-    from('build/intermediates/bundles/default/')
+task makeAar(type: Copy) {
+    from('build/outputs/aar/')
     into('build/release/')
-    include('classes.jar')
-    rename ('classes.jar', PUBLISH_ARTIFACT_ID + '-' +  myProject.version + '.jar')
+    include('sdk-release.aar')
+    include('notifications-handler-release.aar')
+    rename ('sdk-release.aar', PUBLISH_ARTIFACT_ID + '-' +  myProject.version + '.aar')
+    rename ('notifications-handler-release.aar', PUBLISH_ARTIFACT_ID + '-' +  myProject.version + '.aar')
 }
 
-makeJar.dependsOn(clearJar, build)
+makeAar.dependsOn(clearAar, build)
 
 task androidJavadocs(type: Javadoc) {
     source = android.sourceSets.main.java.srcDirs
@@ -51,5 +60,5 @@ task androidSourcesJar(type: Jar) {
 artifacts {
     archives androidSourcesJar
     //archives androidJavadocsJar
-    archives file : file('build/release/' + PUBLISH_ARTIFACT_ID + '-' + myProject.version + '.jar')
+    archives file : file('build/release/' + PUBLISH_ARTIFACT_ID + '-' + myProject.version + '.aar')
 }

--- a/sdk/android-libraries.gradle
+++ b/sdk/android-libraries.gradle
@@ -60,5 +60,5 @@ task androidSourcesJar(type: Jar) {
 artifacts {
     archives androidSourcesJar
     //archives androidJavadocsJar
-    archives file : file('build/release/' + PUBLISH_ARTIFACT_ID + '-' + myProject.version + '.aar')
+    archives file : file('build/release/' + PUBLISH_ARTIFACT_ID + '-' + myProject.version + '.aar'), type: 'aar', classifier: 'sources'
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -21,5 +21,5 @@ allprojects {
     }
 
     apply plugin: 'idea'
-    version = '3.4.0'
+    version = '3.5.0'
 }

--- a/sdk/src/notifications-handler/build.gradle
+++ b/sdk/src/notifications-handler/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 ext {
     PUBLISH_ARTIFACT_ID = 'azure-notifications-handler'
+    REPO_URL = 'https://api.bintray.com/maven/microsoftazuremobile/SDK/Notifications-Handler'
 }
 
 group = 'com.microsoft.azure'

--- a/sdk/src/notifications-handler/build.gradle
+++ b/sdk/src/notifications-handler/build.gradle
@@ -4,6 +4,8 @@ ext {
     PUBLISH_ARTIFACT_ID = 'azure-notifications-handler'
 }
 
+group = 'com.microsoft.azure'
+
 android {
     compileSdkVersion 26
     buildToolsVersion '26.0.3'

--- a/sdk/src/sdk/build.gradle
+++ b/sdk/src/sdk/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 ext {
     PUBLISH_ARTIFACT_ID = 'azure-mobile-android'
+    REPO_URL = 'https://api.bintray.com/maven/microsoftazuremobile/SDK/Mobile-Apps-Android'
 }
 
 group = 'com.microsoft.azure'

--- a/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/http/MobileServiceConnection.java
+++ b/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/http/MobileServiceConnection.java
@@ -73,7 +73,7 @@ public class MobileServiceConnection {
     /**
      * Current SDK version
      */
-    private static final String SDK_VERSION = "3.4.0";
+    private static final String SDK_VERSION = "3.5.0";
     /**
      * The MobileServiceClient used for communication with the Mobile Service
      */

--- a/sdk/test/sdk.testapp/src/androidTest/java/com/microsoft/windowsazure/mobileservices/sdk/testapp/test/MobileServiceClientTests.java
+++ b/sdk/test/sdk.testapp/src/androidTest/java/com/microsoft/windowsazure/mobileservices/sdk/testapp/test/MobileServiceClientTests.java
@@ -352,7 +352,7 @@ public class MobileServiceClientTests extends InstrumentationTestCase {
                 String userAgentHeader = "User-Agent";
                 String acceptHeader = "Accept";
                 String acceptEncodingHeader = "Accept-Encoding";
-                String versionNumber = "3.4.0";
+                String versionNumber = "3.5.0";
                 String apiVersionNumber = "2.0.0";
 
                 Headers headers = request.getHeaders();


### PR DESCRIPTION
Pairs @flegallo and @mpodwysocki 

Modifications here allow us to have a working CI build that is slightly more modern with it's usage of *.aar instead of *.jar.

Functional CI build (pointing to the branch) is here: https://msmobilecenter.visualstudio.com/Mobile-Center/_build?definitionId=3373&_a=summary (internal only link)