### PR TITLE
Make updates to fix tests, and make fewer breaking changes for existing users

### DIFF
--- a/e2etest/src/main/java/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/tests/PushTests.java
+++ b/e2etest/src/main/java/com/microsoft/windowsazure/mobileservices/zumoe2etestapp/tests/PushTests.java
@@ -58,7 +58,7 @@ public class PushTests extends TestGroup {
 
     private final static String TOPIC_SPORTS = "topic:Sports";
     private final static String TOPIC_NEWS = "topic:News";
-    private final static String PLATFORM =  "fcm";
+    private final static String PLATFORM =  "gcm";
     private final static String TEMPLATE_NAME = "FcmTemplate";
 
     public PushTests() {
@@ -333,7 +333,7 @@ public class PushTests extends TestGroup {
 
                 this.log("sending push message:" + sentPayload.toString());
                 client.invokeApi("Push", item).get();
-                if (PushMessageManager.instance.isPushMessageReceived(30000, pushContent).get()) {
+                if (PushMessageManager.instance.isPushMessageReceived(60000, pushContent).get()) {
                     this.log(sentPayload.toString() + " message received");
                     return true;
                 } else {
@@ -429,7 +429,7 @@ public class PushTests extends TestGroup {
                 client.invokeApi("Push", item).get();
 
                 if (tag.equals(TOPIC_SPORTS)) {
-                    if (PushMessageManager.instance.isPushMessageReceived(30000, pushContent).get()) {
+                    if (PushMessageManager.instance.isPushMessageReceived(60000, pushContent).get()) {
                         this.log(sentPayload.toString() + " message received because we registered tag " + tag);
                         return true;
                     } else {
@@ -438,7 +438,7 @@ public class PushTests extends TestGroup {
                         return false;
                     }
                 } else {
-                    if (!PushMessageManager.instance.isPushMessageReceived(10000, pushContent).get()) {
+                    if (!PushMessageManager.instance.isPushMessageReceived(60000, pushContent).get()) {
                         this.log("We shouldn't receive message " + sentPayload.toString() + " because we didn't register tag " + tag);
                         return true;
                     } else {
@@ -522,7 +522,7 @@ public class PushTests extends TestGroup {
                 this.log("sending push message:" + item.toString());
                 client.invokeApi("Push", item).get();
 
-                if (PushMessageManager.instance.isPushMessageReceived(30000, expectedPushMessage).get()) {
+                if (PushMessageManager.instance.isPushMessageReceived(60000, expectedPushMessage).get()) {
                     this.log("push received:" + expectedPushMessage.toString());
                     return true;
                 } else {
@@ -612,7 +612,7 @@ public class PushTests extends TestGroup {
 
                 this.log("sending push message:" + sentPayload.toString() + " with tag " + TOPIC_SPORTS);
                 client.invokeApi("Push", item).get();
-                if (PushMessageManager.instance.isPushMessageReceived(30000, pushContent).get()) {
+                if (PushMessageManager.instance.isPushMessageReceived(60000, pushContent).get()) {
                     this.log(sentPayload.toString() + " message received because we registered tag " + TOPIC_SPORTS);
                     return true;
                 } else {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -7,8 +7,8 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
-        classpath 'com.google.gms:google-services:3.0.0'
-        
+        classpath 'com.google.gms:google-services:4.0.1'
+
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/sdk/src/notifications-handler/src/main/java/com/microsoft/windowsazure/notifications/NotificationsHandler.java
+++ b/sdk/src/notifications-handler/src/main/java/com/microsoft/windowsazure/notifications/NotificationsHandler.java
@@ -22,7 +22,7 @@ public class NotificationsHandler  {
      *
      * @param context           Application context
      */
-    public void onRegistered(Context context) {
+    public void onRegistered(Context context, String token) {
     }
 
     /**
@@ -30,7 +30,7 @@ public class NotificationsHandler  {
      *
      * @param context           Application context
      */
-    public void onUnregistered(Context context) {
+    public void onUnregistered(Context context, String token) {
     }
 
     /**

--- a/sdk/src/notifications-handler/src/main/java/com/microsoft/windowsazure/notifications/NotificationsManager.java
+++ b/sdk/src/notifications-handler/src/main/java/com/microsoft/windowsazure/notifications/NotificationsManager.java
@@ -35,26 +35,18 @@ public class NotificationsManager {
         new AsyncTask<Void, Void, Void>() {
             @Override
             protected Void doInBackground(Void... params) {
-                try {
-                    setHandler(context, notificationsHandlerClass);
+                setHandler(context, notificationsHandlerClass);
 
-                    FirebaseInstanceId.getInstance().getInstanceId().addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
-                        @Override
-                        public void onSuccess(InstanceIdResult instanceIdResult) {
+                FirebaseInstanceId.getInstance().getInstanceId().addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
+                    @Override
+                    public void onSuccess(InstanceIdResult instanceIdResult) {
+                    NotificationsHandler handler = getHandler(context);
 
-                            NotificationsHandler handler = getHandler(context);
-
-                            if (handler != null) {
-                                handler.onRegistered(context);
-                            }
-
-                        }
-                    });
-
-
-                } catch (Exception e) {
-                    Log.e("NotificationsManager", e.toString());
-                }
+                    if (handler != null) {
+                        handler.onRegistered(context, instanceIdResult.getToken());
+                    }
+                    }
+                });
 
                 return null;
             }
@@ -62,7 +54,7 @@ public class NotificationsManager {
     }
 
     /**
-     * Stops handlind notifications
+     * Stops handling notifications
      *
      * @param context Application Context
      */
@@ -71,17 +63,23 @@ public class NotificationsManager {
         new AsyncTask<Void, Void, Void>() {
             @Override
             protected Void doInBackground(Void... params) {
-                try {
-                    FirebaseInstanceId.getInstance().deleteInstanceId();
+                FirebaseInstanceId.getInstance().getInstanceId().addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
+                    @Override
+                    public void onSuccess(InstanceIdResult instanceIdResult) {
+                        try {
 
-                    NotificationsHandler handler = getHandler(context);
+                            FirebaseInstanceId.getInstance().deleteInstanceId();
 
-                    if (handler != null ) {
-                        handler.onUnregistered(context);
+                            NotificationsHandler handler = getHandler(context);
+
+                            if (handler != null ) {
+                                handler.onUnregistered(context, instanceIdResult.getToken());
+                            }
+                        } catch (Exception e) {
+                            Log.e("NotificationsManager", e.toString());
+                        }
                     }
-                } catch (Exception e) {
-                    Log.e("NotificationsManager", e.toString());
-                }
+                });
 
                 return null;
             }

--- a/sdk/test/sdk.testapp/src/androidTest/java/com/microsoft/windowsazure/mobileservices/sdk/testapp/test/PushTests.java
+++ b/sdk/test/sdk.testapp/src/androidTest/java/com/microsoft/windowsazure/mobileservices/sdk/testapp/test/PushTests.java
@@ -52,7 +52,7 @@ public class PushTests extends InstrumentationTestCase {
 
     final String appUrl = "http://myapp.com/";
     final String pnsApiUrl = "push";
-    final String pnsApiPlatform = "fcm";
+    final String pnsApiPlatform = "gcm";
 
     public void testUnregister() throws Throwable {
 


### PR DESCRIPTION
We don't want to make unecessary breaking changes to existing methods. Re-introduce the second parameter `token` for `onRegistered` and `onUnregistered`.

Also made some fixes to existing tests that we managed to run locally.

Pairs @brannon @flegallo @mpodwysocki 