### PR TITLE
Bump version to 3.5.1 to get around maven conflict issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Azure Mobile Services Android SDK Change Log
 
-### Android SDK: Version 3.5.0
+### Android SDK: Version 3.5.1
 - Replace OkHttp 2.5.0 with 3.9.0.
 - [#124](https://github.com/Azure/azure-mobile-apps-android-client/pull/124) Migrate a E2E test application to FCM
 - [#139](https://github.com/Azure/azure-mobile-apps-android-client/pull/139) Use addCallback that requires an executor

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ To get the source code of our SDKs and samples via **git** just type:
 ## Android SDK
 Microsoft Azure Mobile Services can be used with an Android-based device using our Android SDK. You can get the Android SDK in one of the following two ways or you can download the source code using the instructions above.
 
-1. For an Android studio project, add the line `compile 'com.microsoft.azure:azure-mobile-android:3.5.0@aar'` to the app’s Gradle.build file with your desired SDK version plugged in (you can find the latest versions [here](https://go.microsoft.com/fwLink/?LinkID=525472&clcid=0x409)):
+1. For an Android studio project, add the line `compile 'com.microsoft.azure:azure-mobile-android:3.5.1@aar'` to the app’s Gradle.build file with your desired SDK version plugged in (you can find the latest versions [here](https://go.microsoft.com/fwLink/?LinkID=525472&clcid=0x409)):
 2. Eclipse users can [download the Android SDK](http://go.microsoft.com/fwlink/?LinkID=717033&clcid=0x409) directly or can download the source code using the instructions above.
 
 ### Prerequisites

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -21,5 +21,5 @@ allprojects {
     }
 
     apply plugin: 'idea'
-    version = '3.5.0'
+    version = '3.5.1'
 }

--- a/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/http/MobileServiceConnection.java
+++ b/sdk/src/sdk/src/main/java/com/microsoft/windowsazure/mobileservices/http/MobileServiceConnection.java
@@ -73,7 +73,7 @@ public class MobileServiceConnection {
     /**
      * Current SDK version
      */
-    private static final String SDK_VERSION = "3.5.0";
+    private static final String SDK_VERSION = "3.5.1";
     /**
      * The MobileServiceClient used for communication with the Mobile Service
      */

--- a/sdk/test/sdk.testapp/src/androidTest/java/com/microsoft/windowsazure/mobileservices/sdk/testapp/test/MobileServiceClientTests.java
+++ b/sdk/test/sdk.testapp/src/androidTest/java/com/microsoft/windowsazure/mobileservices/sdk/testapp/test/MobileServiceClientTests.java
@@ -352,7 +352,7 @@ public class MobileServiceClientTests extends InstrumentationTestCase {
                 String userAgentHeader = "User-Agent";
                 String acceptHeader = "Accept";
                 String acceptEncodingHeader = "Accept-Encoding";
-                String versionNumber = "3.5.0";
+                String versionNumber = "3.5.1";
                 String apiVersionNumber = "2.0.0";
 
                 Headers headers = request.getHeaders();


### PR DESCRIPTION
Due to conflict issues on maven upload (even with files cleaned up), we're trying a version bump as a workaround.